### PR TITLE
[NOD-706] fix: set retry mechanism for event storage resilience

### DIFF
--- a/host.json
+++ b/host.json
@@ -33,7 +33,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "maxTelemetryItemsPerSecond": 5,
+        "maxTelemetryItemsPerSecond": 20,
         "includedTypes": "PageView;Trace;Dependency;Request",
         "excludedTypes": "Exception;Event;CustomEvent"
       }

--- a/host.json
+++ b/host.json
@@ -6,8 +6,8 @@
   },
   "extensions": {
     "tracing": {
-      "traceInputsAndOutputs": true,
-      "traceReplayEvents": true
+      "traceInputsAndOutputs": false,
+      "traceReplayEvents": false
     },
     "eventHubs": {
       "maxEventBatchSize" : 10,
@@ -33,7 +33,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "maxTelemetryItemsPerSecond": 20,
+        "maxTelemetryItemsPerSecond": 5,
         "includedTypes": "PageView;Trace;Dependency;Request",
         "excludedTypes": "Exception;Event;CustomEvent"
       }

--- a/host.json
+++ b/host.json
@@ -6,8 +6,8 @@
   },
   "extensions": {
     "tracing": {
-      "traceInputsAndOutputs": false,
-      "traceReplayEvents": false
+      "traceInputsAndOutputs": true,
+      "traceReplayEvents": true
     },
     "eventHubs": {
       "maxEventBatchSize" : 10,

--- a/host.json
+++ b/host.json
@@ -28,7 +28,7 @@
   "logging": {
     "logLevel": {
       "default": "Error",
-      "Function.EventHubNodoVerifyKOEventToDSProcessor": "Warning"
+      "Function.EventHubNodoVerifyKOEventToDSProcessor": "Information"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4-5-NOD-706-error-tracing</version>
+    <version>0.1.4-6-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4-3-NOD-706-error-tracing</version>
+    <version>0.1.4-4-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4-2-NOD-706-error-tracing</version>
+    <version>0.1.4-3-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4-1-NOD-706-error-tracing</version>
+    <version>0.1.4-2-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4-6-NOD-706-error-tracing</version>
+    <version>0.1.4-7-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.4-1-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>nodoverifykotodatastore</artifactId>
-    <version>0.1.4-4-NOD-706-error-tracing</version>
+    <version>0.1.4-5-NOD-706-error-tracing</version>
     <packaging>jar</packaging>
 
     <name>Nodo Verify KO to datastore Fn</name>

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -23,6 +23,7 @@ import java.util.regex.Matcher;
 public class NodoVerifyKOEventToDataStore {
 
 	@FunctionName("EventHubNodoVerifyKOEventToDSProcessor")
+	@ExponentialBackoffRetry(maxRetryCount = 5, maximumInterval = "00:15:00", minimumInterval = "00:00:10")
     public void processNodoVerifyKOEvent (
             @EventHubTrigger(
                     name = "NodoVerifyKOEvent",
@@ -79,7 +80,7 @@ public class NodoVerifyKOEventToDataStore {
 					eventsToPersist.add(event);
 				}
 
-				logger.log(Level.INFO, () -> String.format("Performing event ingestion: InvocationId [%s], Events: %s", context.getInvocationId(), extractTraceForEventsToPersist(eventsToPersist)));
+				logger.log(Level.INFO, () -> String.format("Performing event ingestion: InvocationId [%s], Retry Attempt [%d], Events: %s", context.getInvocationId(), context.getRetryContext() == null ? -1 : context.getRetryContext().getRetrycount(), extractTraceForEventsToPersist(eventsToPersist)));
 
 				// save all events in the retrieved batch in the storage
 				persistEventBatch(logger, documentdb, eventsToPersist);

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -23,6 +23,7 @@ import java.util.regex.Matcher;
 public class NodoVerifyKOEventToDataStore {
 
 	@FunctionName("EventHubNodoVerifyKOEventToDSProcessor")
+	@ExponentialBackoffRetry(maxRetryCount = 0, minimumInterval = "", maximumInterval = "")
     public void processNodoVerifyKOEvent (
             @EventHubTrigger(
                     name = "NodoVerifyKOEvent",
@@ -38,7 +39,7 @@ public class NodoVerifyKOEventToDataStore {
 					createIfNotExists = false,
 					connection = "COSMOS_CONN_STRING")
 			@NonNull OutputBinding<List<Object>> documentdb,
-            final ExecutionContext context) throws AppException {
+            final ExecutionContext context) {
 
 		String errorCause = null;
 		boolean isPersistenceOk = true;

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -79,7 +79,7 @@ public class NodoVerifyKOEventToDataStore {
 					eventsToPersist.add(event);
 				}
 
-				logger.log(Level.INFO, () -> String.format("Performing event ingestion: InvocationId [%s], Events: [%s]", context.getInvocationId(), extractTraceForEventsToPersist(eventsToPersist)));
+				logger.log(Level.INFO, () -> String.format("Performing event ingestion: InvocationId [%s], Events: %s", context.getInvocationId(), extractTraceForEventsToPersist(eventsToPersist)));
 
 				// save all events in the retrieved batch in the storage
 				persistEventBatch(logger, documentdb, eventsToPersist);

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -23,7 +23,6 @@ import java.util.regex.Matcher;
 public class NodoVerifyKOEventToDataStore {
 
 	@FunctionName("EventHubNodoVerifyKOEventToDSProcessor")
-	@ExponentialBackoffRetry(maxRetryCount = 0, minimumInterval = "", maximumInterval = "")
     public void processNodoVerifyKOEvent (
             @EventHubTrigger(
                     name = "NodoVerifyKOEvent",

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -110,8 +110,8 @@ public class NodoVerifyKOEventToDataStore {
         return Arrays.toString(eventsToPersist.stream()
                 .map(event -> {
                     Map<String, Object> eventMap = (Map<String, Object>) event;
-					String rowKey = getEventField(eventMap, "id", String.class, "UNKNOWN-ROW-KEY");
-					String partitionKey = getEventField(eventMap, Constants.PARTITION_KEY_EVENT_FIELD, String.class, "UNKNOWN-PARTITION-KEY");
+					String rowKey = getEventField(eventMap, "id", String.class, "null");
+					String partitionKey = getEventField(eventMap, Constants.PARTITION_KEY_EVENT_FIELD, String.class, "null");
 					Long eventTimestamp = getEventField(eventMap, "faultBean.timestamp", Long.class, -1L);
                     return String.format("{PartitionKey: %s, RowKey: %s, EventTimestamp: %d}", partitionKey, rowKey, eventTimestamp);
                 })

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -25,7 +25,7 @@ public class NodoVerifyKOEventToDataStore {
 	private static final Integer MAX_RETRY_COUNT = 5;
 
 	@FunctionName("EventHubNodoVerifyKOEventToDSProcessor")
-	@ExponentialBackoffRetry(maxRetryCount = MAX_RETRY_COUNT, maximumInterval = "00:15:00", minimumInterval = "00:00:10")
+	@ExponentialBackoffRetry(maxRetryCount = 5, maximumInterval = "00:15:00", minimumInterval = "00:00:10")
     public void processNodoVerifyKOEvent (
             @EventHubTrigger(
                     name = "NodoVerifyKOEvent",

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/NodoVerifyKOEventToDataStore.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.nodoverifykotodatastore;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.OutputBinding;
 import com.microsoft.azure.functions.annotation.*;
+import it.gov.pagopa.nodoverifykotodatastore.exception.AppException;
 import it.gov.pagopa.nodoverifykotodatastore.util.Constants;
 import it.gov.pagopa.nodoverifykotodatastore.util.ObjectMapperUtils;
 import lombok.NonNull;
@@ -37,10 +38,13 @@ public class NodoVerifyKOEventToDataStore {
 					createIfNotExists = false,
 					connection = "COSMOS_CONN_STRING")
 			@NonNull OutputBinding<List<Object>> documentdb,
-            final ExecutionContext context) {
+            final ExecutionContext context) throws AppException {
+
+		String errorCause = null;
+		boolean isPersistenceOk = true;
 
 		Logger logger = context.getLogger();
-		logger.log(Level.INFO, () -> String.format("Persisting [%d] events...", events.size()));
+		logger.log(Level.FINE, () -> String.format("Persisting [%d] events...", events.size()));
 
         try {
         	if (events.size() == properties.length) {
@@ -75,19 +79,44 @@ public class NodoVerifyKOEventToDataStore {
 					eventsToPersist.add(event);
 				}
 
+				logger.log(Level.INFO, () -> String.format("Performing event ingestion: InvocationId [%s], Events: [%s]", context.getInvocationId(), extractTraceForEventsToPersist(eventsToPersist)));
+
 				// save all events in the retrieved batch in the storage
 				persistEventBatch(logger, documentdb, eventsToPersist);
             } else {
-				logger.log(Level.SEVERE, () -> String.format("[ALERT][VerifyKOToDS] AppException - Error processing events, lengths do not match: [events: %d - properties: %d]", events.size(), properties.length));
+				isPersistenceOk = false;
+				errorCause = String.format("[ALERT][VerifyKOToDS] AppException - Error processing events, lengths do not match: [events: %d - properties: %d]", events.size(), properties.length);
             }
         } catch (IllegalArgumentException e) {
-			logger.log(Level.SEVERE, () -> "[ALERT][VerifyKOToDS] AppException - Illegal argument exception on cosmos nodo-verify-ko-events msg ingestion at " + LocalDateTime.now() + " : " + e);
+			isPersistenceOk = false;
+			errorCause = "[ALERT][VerifyKOToDS] AppException - Illegal argument exception on cosmos nodo-verify-ko-events msg ingestion at " + LocalDateTime.now() + " : " + e;
 		} catch (IllegalStateException e) {
-			logger.log(Level.SEVERE, () -> "[ALERT][VerifyKOToDS] AppException - Missing argument exception on nodo-verify-ko-events msg ingestion at " + LocalDateTime.now() + " : " + e);
+			isPersistenceOk = false;
+			errorCause = "[ALERT][VerifyKOToDS] AppException - Missing argument exception on nodo-verify-ko-events msg ingestion at " + LocalDateTime.now() + " : " + e;
 		} catch (Exception e) {
-			logger.log(Level.SEVERE, () -> "[ALERT][VerifyKOToDS] AppException - Generic exception on cosmos nodo-verify-ko-events msg ingestion at " + LocalDateTime.now() + " : " + e.getMessage());
+			isPersistenceOk = false;
+			errorCause = "[ALERT][VerifyKOToDS] AppException - Generic exception on cosmos nodo-verify-ko-events msg ingestion at " + LocalDateTime.now() + " : " + e.getMessage();
         }
+
+		if (!isPersistenceOk) {
+			String finalErrorCause = errorCause;
+			logger.log(Level.SEVERE, () -> finalErrorCause);
+			throw new AppException(errorCause);
+		}
     }
+
+	@SuppressWarnings({"unchecked"})
+	private static String extractTraceForEventsToPersist(List<Object> eventsToPersist) {
+        return Arrays.toString(eventsToPersist.stream()
+                .map(event -> {
+                    Map<String, Object> eventMap = (Map<String, Object>) event;
+					String rowKey = getEventField(eventMap, "id", String.class, "UNKNOWN-ROW-KEY");
+					String partitionKey = getEventField(eventMap, Constants.PARTITION_KEY_EVENT_FIELD, String.class, "UNKNOWN-PARTITION-KEY");
+					Long eventTimestamp = getEventField(eventMap, "faultBean.timestamp", Long.class, -1L);
+                    return String.format("{PartitionKey: %s, RowKey: %s, EventTimestamp: %d}", partitionKey, rowKey, eventTimestamp);
+                })
+				.toArray());
+	}
 
 	private String fixDateTime(String faultBeanTimestamp) {
 		int dotIndex = faultBeanTimestamp.indexOf('.');
@@ -116,7 +145,7 @@ public class NodoVerifyKOEventToDataStore {
 
 	private void persistEventBatch(Logger logger, OutputBinding<List<Object>> documentdb, List<Object> eventsToPersistCosmos) {
 		documentdb.setValue(eventsToPersistCosmos);
-		logger.info("Done processing events");
+		logger.log(Level.FINE, () -> "Done processing events");
 	}
 
 	private String generatePartitionKey(Map<String, Object> event, String insertedDateValue) {
@@ -127,7 +156,8 @@ public class NodoVerifyKOEventToDataStore {
 				getEventField(event, Constants.PSP_ID_EVENT_FIELD, String.class, Constants.NA);
 	}
 
-	private <T> T getEventField(Map<String, Object> event, String name, Class<T> clazz, T defaultValue) {
+	@SuppressWarnings({"rawtypes"})
+	private static <T> T getEventField(Map<String, Object> event, String name, Class<T> clazz, T defaultValue) {
 		T field = null;
 		List<String> splitPath = List.of(name.split("\\."));
 		Map eventSubset = event;

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/exception/AppException.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/exception/AppException.java
@@ -1,6 +1,6 @@
 package it.gov.pagopa.nodoverifykotodatastore.exception;
 
-public class AppException extends Exception {
+public class AppException extends RuntimeException {
 
     public AppException(String message) {
         super(message);

--- a/src/main/java/it/gov/pagopa/nodoverifykotodatastore/exception/AppException.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykotodatastore/exception/AppException.java
@@ -1,0 +1,8 @@
+package it.gov.pagopa.nodoverifykotodatastore.exception;
+
+public class AppException extends Exception {
+
+    public AppException(String message) {
+        super(message);
+    }
+}

--- a/src/test/resources/events/event_ko_2.json
+++ b/src/test/resources/events/event_ko_2.json
@@ -1,0 +1,20 @@
+{
+  "id": "uuid-001",
+  "version": "2",
+  "debtorPosition": {
+    "modelType": "2",
+    "noticeNumber": "302040000090000000",
+    "amount": "50.00"
+  },
+  "creditor": {
+    "idPA": "77777777777",
+    "ccPost": "777777777777",
+    "idBrokerPA": "77777777777",
+    "idStation": "77777777777_01"
+  },
+  "faultBean": {
+    "faultCode": "PPT_STAZIONE_INT_PA_ERRORE_RESPONSE",
+    "description": "EC service error at 2023-01-01T12:00:00",
+    "timestamp": "2023-12-12T18:34:39.860654"
+  }
+}


### PR DESCRIPTION
This PR contains some little changes made in order to correctly perform the handling of the events. These changes permits to execute correctly the retry mechanism, handling all expected and checked exceptions occurred and throwing an unchecked exception, as described as "best practice" in Azure Function's documentation. Previously, all the exception were suppressed and only an error log was shown, used only by the alarming system that reads AppInsights logs.    
This PR also provide a more explicative log for analyzed events in order to perform a more simple debugging process with Application Insights when an alert occurs. 

#### List of Changes
 - Add annotation for explicit definition of retry mechanism if an unchecked exception is thrown 
 - Removed exception suppression, launching a specific `AppException` when an error occurs
 - Added event trace log, needed for tracking examined events with Application Insights when an error occurs
 - Incremented Azure Function's log level, from `Warning` to `Information`
 - Moved all logs in INFO level to FINE level
 - Updated JUnit tests

#### Motivation and Context
These changes are needed in order to track the errors and to permits the Azure Functions' systems to executes retry strategy correctly.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.